### PR TITLE
Makes Chrome extension more dev-friendly

### DIFF
--- a/chrome/ScreenSharing/content-script.js
+++ b/chrome/ScreenSharing/content-script.js
@@ -59,6 +59,14 @@ window.addEventListener('message', function (event) {
 // inform browser that you're available!
 window.postMessage(response('extensionLoaded'), '*');
 
-var isInstalledNode = document.createElement('div');
-isInstalledNode.id = 'oneroom-screensharing-opentok-extension-is-installed';
-document.body.appendChild(isInstalledNode);
+var installedNodeId = 'oneroom-screensharing-opentok-extension-is-installed';
+var isInstalledNode = document.getElementById(installedNodeId);
+// Only mess with the page if we found the element that we expect. We do this,
+// because the easiest way to make a development-friendly version of this
+// extension is to allow it to run on localhost and ngrok.com domains, but we do
+// not want to mess with pages that are not expecting this extension to run on.
+if (isInstalledNode) {
+  var affirmativeNode = document.createElement('div');
+  affirmativeNode.setAttribute('data-type', 'chrome');
+  isInstalledNode.appendChild(affirmativeNode);
+}

--- a/chrome/ScreenSharing/manifest.json
+++ b/chrome/ScreenSharing/manifest.json
@@ -1,7 +1,7 @@
 {
   "name" : "OneRoom Screen Sharing",
   "author": "OneRoom",
-  "version" : "1.1",
+  "version" : "1.2",
   "manifest_version" : 2,
   "minimum_chrome_version": "34",
   "description" : "This Chrome extension enables screen sharing on http://joinoneroom.com/.",
@@ -13,7 +13,7 @@
   "content_scripts": [ {
    "js": [ "content-script.js" ],
    "all_frames": true,
-   "matches": ["https://*.joinoneroom.com/*"]
+   "matches": ["https://*.joinoneroom.com/*", "https://localhost/*", "https://*.ngrok.com/*", "https://*.ngrok.io/*"]
   }],
   "icons": {
     "16": "logo16.png",


### PR DESCRIPTION
The extension now checks for the presense of a specific div, and only if it
exists will it modify the page. This way, we can have the extension run on
localhost and ngrok domains in addition to the joinoneroom domain, without the
fear of the extension modifying someone else's page.
